### PR TITLE
CMake build & first CI/CD pipeline

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,57 @@
+name: Build and Release Firmware
+
+on:
+  push:
+    tags:
+      - '*' # Triggers on any tag
+  pull_request:
+    branches:
+      - main  # Trigger on PRs to the main branch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Build Docker image
+      run: cd AxxSolder_firmware && docker build -t firmware-builder -f Containerfile .
+
+    - name: Run firmware build and copy artifact
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        echo "FIRMWARE_PATH=AxxSolder-${GITHUB_REF#refs/tags/}.bin" >> $GITHUB_ENV
+        cd AxxSolder_firmware
+        docker run --rm \
+          -v ${{ github.workspace }}:/workspace \
+          -w /workspace \
+          firmware-builder \
+          cp /app/build/AxxSolder.bin /workspace/${FIRMWARE_PATH}
+    
+    - name: Upload firmware artifact
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: actions/upload-artifact@v4
+      with:
+        name: firmware
+        path: ${{ env.FIRMWARE_PATH }}
+
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/') #will only run on tags, never on PRs
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download firmware artifact
+      uses: actions/download-artifact@v4
+      with:
+         name: firmware
+
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: ${{ github.workspace }}/*.bin
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -19,10 +19,12 @@ jobs:
     - name: Build Docker image
       run: cd AxxSolder_firmware && docker build -t firmware-builder -f Containerfile .
 
+    - name: Set firmware path
+      run: echo "FIRMWARE_PATH=AxxSolder-${GITHUB_REF#refs/tags/}.bin" >> $GITHUB_ENV
+
     - name: Run firmware build and copy artifact
       if: startsWith(github.ref, 'refs/tags/')
       run: |
-        echo "FIRMWARE_PATH=AxxSolder-${GITHUB_REF#refs/tags/}.bin" >> $GITHUB_ENV
         cd AxxSolder_firmware
         docker run --rm \
           -v ${{ github.workspace }}:/workspace \

--- a/AxxSolder_firmware/CMakeLists.txt
+++ b/AxxSolder_firmware/CMakeLists.txt
@@ -1,0 +1,78 @@
+#Inspired by https://github.com/jasonyang-ee/STM32-CMAKE-TEMPLATE
+cmake_minimum_required(VERSION 3.29)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+set(CMAKE_C_STANDARD                11)
+set(CMAKE_C_STANDARD_REQUIRED       ON)
+set(CMAKE_C_EXTENSIONS              ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS   ON)
+set(CMAKE_TOOLCHAIN_FILE            gcc-arm-none-eabi)
+project(AxxSolder C ASM)
+set(linker_script_SRC               ${CMAKE_SOURCE_DIR}/STM32G431CBTX_FLASH.ld)
+set(EXECUTABLE                      ${CMAKE_PROJECT_NAME})
+
+file(GLOB source_list
+    ${CMAKE_SOURCE_DIR}/Core/Src/*.c
+    ${CMAKE_SOURCE_DIR}/Drivers/STM32G4xx_HAL_Driver/Src/*.c
+    ${CMAKE_SOURCE_DIR}/Drivers/LCD/*.c
+    ${CMAKE_SOURCE_DIR}/Drivers/UGUI/*.c
+    ${CMAKE_SOURCE_DIR}/Drivers/UGUI/Fonts/*.c
+)
+
+set(include_list ${include_list}
+    ${CMAKE_SOURCE_DIR}/Core/Inc
+    ${CMAKE_SOURCE_DIR}/Drivers/LCD
+    ${CMAKE_SOURCE_DIR}/Drivers/UGUI
+    ${CMAKE_SOURCE_DIR}/Drivers/CMSIS/Device/ST/STM32G4xx/Include
+    ${CMAKE_SOURCE_DIR}/Drivers/CMSIS/Include
+    ${CMAKE_SOURCE_DIR}/Drivers/STM32G4xx_HAL_Driver/Inc
+    ${CMAKE_SOURCE_DIR}/Drivers/STM32G4xx_HAL_Driver/Inc/Legacy
+)
+
+add_executable(${EXECUTABLE} ${source_list} ${CMAKE_SOURCE_DIR}/Core/Startup/startup_stm32g431cbtx.s)
+
+target_include_directories(${EXECUTABLE} PRIVATE ${include_list})
+
+target_compile_definitions(${EXECUTABLE} PRIVATE 
+    "USE_HAL_DRIVER"
+    "STM32G431xx"
+)
+
+set(CPU_PARAMETERS ${CPU_PARAMETERS}
+	-mthumb
+	-mcpu=cortex-m4
+	-mfpu=fpv4-sp-d16
+	-mfloat-abi=hard
+)
+
+target_compile_options(${EXECUTABLE} PRIVATE
+    ${CPU_PARAMETERS}
+	-Wall
+	-Wpedantic
+	-Wno-unused-parameter
+)
+
+target_link_options(${EXECUTABLE} PRIVATE
+	-T${linker_script_SRC}
+	${CPU_PARAMETERS}
+	-Wl,-Map=${CMAKE_PROJECT_NAME}.map
+	--specs=nosys.specs
+	-u _printf_float                # STDIO float formatting support
+	-Wl,--start-group
+	-lc
+	-lm
+	-Wl,--end-group
+	-Wl,--print-memory-usage
+)
+
+add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
+	COMMAND ${CMAKE_SIZE} $<TARGET_FILE:${EXECUTABLE}>
+)
+
+add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
+	COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${EXECUTABLE}> ${EXECUTABLE}.hex
+)
+
+add_custom_command(TARGET ${EXECUTABLE} POST_BUILD
+	COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${EXECUTABLE}> ${EXECUTABLE}.bin
+)

--- a/AxxSolder_firmware/Containerfile
+++ b/AxxSolder_firmware/Containerfile
@@ -1,0 +1,20 @@
+#Inspired by https://github.com/jasonyang-ee/STM32-Dockerfile/tree/main
+FROM alpine:3.20.3
+
+RUN set -eux; \
+    apk add --no-cache --virtual build-dependencies \
+	    build-base=0.5-r3 \
+        gcc=13.2.1_git20240309-r0 \
+        gcc-arm-none-eabi=14.1.0-r0 \
+        cmake=3.29.3-r0 \
+        newlib=4.4.0.20231231-r0 \
+    ;
+
+WORKDIR /app
+
+COPY . .
+
+RUN set -eux; \
+    cmake -S . -B build; \
+    cmake --build build -j$(nproc); \
+    ls -al build;

--- a/AxxSolder_firmware/cmake/gcc-arm-none-eabi.cmake
+++ b/AxxSolder_firmware/cmake/gcc-arm-none-eabi.cmake
@@ -1,0 +1,19 @@
+set(CMAKE_SYSTEM_NAME               Generic)
+set(CMAKE_SYSTEM_PROCESSOR          arm)
+
+# Some default GCC settings
+# arm-none-eabi- must be part of path environment
+set(TOOLCHAIN_PREFIX                arm-none-eabi-)
+set(FLAGS                           "-fdata-sections -ffunction-sections --specs=nano.specs -Wl,--gc-sections")
+set(CPP_FLAGS                       "-fno-rtti -fno-exceptions -fno-threadsafe-statics")
+
+# Define compiler settings
+set(CMAKE_C_COMPILER                ${TOOLCHAIN_PREFIX}gcc ${FLAGS})
+set(CMAKE_ASM_COMPILER              ${CMAKE_C_COMPILER})
+set(CMAKE_OBJCOPY                   ${TOOLCHAIN_PREFIX}objcopy)
+set(CMAKE_SIZE                      ${TOOLCHAIN_PREFIX}size)
+
+set(CMAKE_EXECUTABLE_SUFFIX_ASM     ".elf")
+set(CMAKE_EXECUTABLE_SUFFIX_C       ".elf")
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)


### PR DESCRIPTION
We can now build the firmware using CMake.

CI/CD pipelines automatizes the build on PR and release on tags.