### PR TITLE
Feat/lcd driver split

### DIFF
--- a/AxxSolder_firmware/CMakeLists.txt
+++ b/AxxSolder_firmware/CMakeLists.txt
@@ -33,9 +33,17 @@ add_executable(${EXECUTABLE} ${source_list} ${CMAKE_SOURCE_DIR}/Core/Startup/sta
 
 target_include_directories(${EXECUTABLE} PRIVATE ${include_list})
 
-target_compile_definitions(${EXECUTABLE} PRIVATE 
+# LCD options — defaults match current hardware (ST7789, 240×320, rotation 2)
+set(LCD_CONTROLLER "ST7789"  CACHE STRING "LCD controller (ST7789 or ST7735)")
+set(LCD_SIZE       "240X320" CACHE STRING "LCD panel size: 240X320 240X280 240X240 135X240 160X128 128X128 160X80")
+set(LCD_ROTATION   "2"       CACHE STRING "Default LCD rotation 0-3")
+
+target_compile_definitions(${EXECUTABLE} PRIVATE
     "USE_HAL_DRIVER"
     "STM32G431xx"
+    "USE_${LCD_CONTROLLER}"
+    "LCD_${LCD_SIZE}"
+    "LCD_ROTATION=${LCD_ROTATION}"
 )
 
 set(CPU_PARAMETERS ${CPU_PARAMETERS}

--- a/AxxSolder_firmware/Drivers/LCD/lcd.c
+++ b/AxxSolder_firmware/Drivers/LCD/lcd.c
@@ -2,59 +2,6 @@
 #include "lcd.h"
 
 
-/* Arg count, CMD, Args if any */
-#if defined USE_ST7735
-const uint8_t init_cmd[] = {
-    0,  CMD_SLPOUT,
-//  3,  CMD_FRMCTR1, 0x01, 0x2C, 0x2D,                     // Standard frame rate
-//  3,  CMD_FRMCTR2, 0x01, 0x2C, 0x2D,                     // Standard frame rate
-//  6,  CMD_FRMCTR3, 0x01, 0x2C, 0x2D, 0x01, 0x2C, 0x2D,   // Standard frame rate
-    3,  CMD_FRMCTR1, 0x01, 0x01, 0x01,                     // Max
-    3,  CMD_FRMCTR2, 0x01, 0x01, 0x01,                     // Max
-    6,  CMD_FRMCTR3, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,   // Max frame rate
-    1,  CMD_INVCTR,  0x07,
-    3,  CMD_PWCTR1,  0xA2, 0x02, 0x84,
-    1,  CMD_PWCTR2,  0xC5,
-    2,  CMD_PWCTR3,  0x0A, 0x00,
-    2,  CMD_PWCTR4,  0x8A, 0x2A,
-    2,  CMD_PWCTR5,  0x8A, 0xEE,
-    1,  CMD_VMCTR1,  0x0E,
-    1,  CMD_INVOFF,  0x00,
-    1,  CMD_COLMOD,  0x05,
-    2,  CMD_CASET,   0x00, LCD_WIDTH-1,
-    2,  CMD_RASET,   0x00, LCD_HEIGHT-1,
-    1,  CMD_MADCTL,  LCD_ROTATION_CMD,
-    16, CMD_GMCTRP1, 0x02, 0x1c, 0x07, 0x12, 0x37, 0x32, 0x29, 0x2d, 0x29, 0x25, 0x2B, 0x39, 0x00, 0x01, 0x03, 0x10,
-    16, CMD_GMCTRN1, 0x03, 0x1d, 0x07, 0x06, 0x2E, 0x2C, 0x29, 0x2D, 0x2E, 0x2E, 0x37, 0x3F, 0x00, 0x00, 0x02, 0x10,
-    0,  CMD_NORON,
-};
-#elif defined USE_ST7789
-const uint8_t init_cmd[] = {
-    0,  CMD_SLPOUT,
-    1,  CMD_COLMOD,  CMD_COLOR_MODE_16bit,
-    5,  CMD_PORCTRL, 0x0C, 0x0C, 0x00, 0x33, 0x33,   // Standard porch
-  //5,  CMD_PORCTRL, 0x01, 0x01, 0x00, 0x11, 0x11,   // Minimum porch (7% faster screen refresh rate)
-    1,  CMD_GCTRL,   0x35,                           // Gate Control, Default value
-    1,  CMD_VCOMS,   0x19,                           // VCOM setting 0.725v (default 0.75v for 0x20)
-    1,  CMD_LCMCTRL, 0X2C,                           // LCMCTRL, Default value
-    1,  CMD_VDVVRHEN,0x01,                           // VDV and VRH command Enable, Default value
-    1,  CMD_VRHS,    0x12,                           // VRH set, +-4.45v (default +-4.1v for 0x0B)
-    1,  CMD_VDVS,    0x20,                           // VDV set, Default value
-    1,  CMD_FRCTRL2, 0x0F,                           // Frame rate control in normal mode, Default refresh rate (60Hz)
-  //1,  CMD_FRCTRL2, 0x01,                           // Frame rate control in normal mode, Max refresh rate (111Hz)
-    2,  CMD_PWCTRL1, 0xA4, 0xA1,
-    1,  CMD_MADCTL,  LCD_ROTATION_CMD,
-    14, CMD_GMCTRP1, 0xD0, 0x04, 0x0D, 0x11, 0x13, 0x2B, 0x3F, 0x54, 0x4C, 0x18, 0x0D, 0x0B, 0x1F, 0x23,
-    14, CMD_GMCTRN1, 0xD0, 0x04, 0x0C, 0x11, 0x13, 0x2C, 0x3F, 0x44, 0x51, 0x2F, 0x1F, 0x1F, 0x20, 0x23,
-    0,  CMD_INVON,
-    0,  CMD_NORON
-};
-
-
-
-#endif
-
-
 
 
 static void LCD_Update(void);
@@ -111,7 +58,6 @@ static void setSPI_Size(int8_t size){
 
 
 #ifdef USE_DMA
-#define DMA_Min_Pixels    32             // Don't use DMA for small transfers? Setting this to 1 will always use DMA
 #define mem_increase      1
 #define mem_fixed         0
 
@@ -275,50 +221,16 @@ static void LCD_ReadCmd(uint8_t cmd, uint8_t *data, uint8_t count)
  */
 void LCD_SetRotation(uint8_t m)
 {
-  uint8_t cmd[] = { CMD_MADCTL, 0};
-
-  m = m % 4; // can't be higher than 3
-
-  switch (m)
-  {
-  case 2:
-#if LCD_IS_160X80
-    cmd[1] = CMD_MADCTL_MX | CMD_MADCTL_MY | CMD_MADCTL_BGR;
-#else
-    cmd[1] = CMD_MADCTL_MX | CMD_MADCTL_MY | CMD_MADCTL_RGB;
-#endif
-    break;
-  case 3:
-#if CMD_IS_160X80
-    cmd[1] = CMD_MADCTL_MY | CMD_MADCTL_MV | CMD_MADCTL_BGR;
-#else
-    cmd[1] = CMD_MADCTL_MY | CMD_MADCTL_MV | CMD_MADCTL_RGB;
-#endif
-    break;
-  case 0:
-#if CMD_IS_160X80
-    cmd[1] = CMD_MADCTL_BGR;
-#else
-    cmd[1] = CMD_MADCTL_RGB;
-#endif
-    break;
-  case 1:
-#if CMD_IS_160X80
-    cmd[1] = CMD_MADCTL_MX | CMD_MADCTL_MV | CMD_MADCTL_BGR;
-#else
-    cmd[1] = CMD_MADCTL_MX | CMD_MADCTL_MV | CMD_MADCTL_RGB;
-#endif
-    break;
-  }
+  m = m % 4;
+  uint8_t cmd[] = { CMD_MADCTL, lcd_rotation_cmds[m] };
   LCD_WriteCommand(cmd, sizeof(cmd)-1);
-  //Add a piece to correctly render the UG_FillScreen() function.
-  // Display size update
+
   if (m % 2 == 1) {
-	  device.x_dim = LCD_HEIGHT;
-	  device.y_dim = LCD_WIDTH;
+    device.x_dim = LCD_HEIGHT;
+    device.y_dim = LCD_WIDTH;
   } else {
-	  device.x_dim = LCD_WIDTH;
-	  device.y_dim = LCD_HEIGHT;
+    device.x_dim = LCD_WIDTH;
+    device.y_dim = LCD_HEIGHT;
   }
 }
 
@@ -604,9 +516,9 @@ void LCD_init(void)
 #endif
   UG_FontSetHSpace(0);
   UG_FontSetVSpace(0);
-  for(uint16_t i=0; i<sizeof(init_cmd); ){
-    LCD_WriteCommand((uint8_t*)&init_cmd[i+1], init_cmd[i]);
-    i += init_cmd[i]+2;
+  for(uint16_t i=0; i<sizeof(lcd_init_cmd); ){
+    LCD_WriteCommand((uint8_t*)&lcd_init_cmd[i+1], lcd_init_cmd[i]);
+    i += lcd_init_cmd[i]+2;
   }
   UG_FillScreen(C_BLACK);               //  Clear screen
   LCD_setPower(ENABLE);

--- a/AxxSolder_firmware/Drivers/LCD/lcd.h
+++ b/AxxSolder_firmware/Drivers/LCD/lcd.h
@@ -96,8 +96,13 @@ extern SPI_HandleTypeDef      LCD_HANDLE;
 #  define LCD_ROTATION 2   /* default: 180° */
 #endif
 
+/* Defaults for IDE builds that don't pass CMake defines */
 #if !defined(USE_ST7789) && !defined(USE_ST7735)
-#  error "No LCD controller selected. Pass -DLCD_CONTROLLER=ST7789 (or ST7735) to CMake."
+#  define USE_ST7789
+#endif
+#if !defined(LCD_240X320) && !defined(LCD_240X280) && !defined(LCD_240X240) && !defined(LCD_135X240) && \
+    !defined(LCD_160X128) && !defined(LCD_128X128) && !defined(LCD_160X80)
+#  define LCD_240X320
 #endif
 
 

--- a/AxxSolder_firmware/Drivers/LCD/lcd.h
+++ b/AxxSolder_firmware/Drivers/LCD/lcd.h
@@ -1,5 +1,5 @@
-#ifndef __ST7735_H__
-#define __ST7735_H__
+#ifndef __LCD_H__
+#define __LCD_H__
 
 #include "images.h"
 #include "ugui.h"
@@ -7,176 +7,6 @@
 
 /* For demo only. Minimum is 32, 128 and higher will enable all tests */
 #define DEMO_FLASH_KB 128
-
-/* choose a Hardware SPI port to use. */
-#define LCD_HANDLE            hspi2
-
-/* Pin connections. Use same names as in CubeMX */
-#define LCD_DC                SPI2_DC_Pin
-#define LCD_RST               SPI2_RST_Pin /* Disable if your display has no RST pin */
-#define LCD_CS                SPI2_CS_Pin  /* Disable if your display has no CS pin */
-//#define LCD_BL              LCD_BL  /* Enable if you need backlight control */
-
-#define USE_DMA                       /* Use DMA for transfers when possible */
-//#define LCD_LOCAL_FB                /* Use local framebuffer. Needs a lot of ram, but removes flickering and redrawing glitches  */
-
-//#define USE_ST7735                    /* LCD Selection */
-#define USE_ST7789
-
-#define LCD_ROTATION 2                /* XY rotation/mirroring. Valid values: 0...3 */
-
-#ifdef USE_ST7735                     /* ST7735 LCD sizes */
-  #define LCD_160X128
-//#define LCD_128X128
-//#define LCD_160X80
-#elif defined USE_ST7789              /* ST7789 LCD sizes */
-//#define LCD_135X240
-//#define LCD_240X240
-//#define LCD_240X280
-#define LCD_240X320
-#endif
-
-
-
-
-#ifdef USE_ST7735
-  #ifdef LCD_160X128
-    #define LCD_X_SHIFT 0
-    #define LCD_Y_SHIFT 0
-    #if (LCD_ROTATION == 0) || (LCD_ROTATION == 2)
-      #define LCD_WIDTH  128
-      #define LCD_HEIGHT 160
-    #elif (LCD_ROTATION == 1) || (LCD_ROTATION == 3)
-      #define LCD_WIDTH  160
-      #define LCD_HEIGHT 128
-    #endif
-  #elif defined LCD_128X128
-    #define LCD_X_SHIFT 0
-    #define LCD_Y_SHIFT 0
-    #define LCD_WIDTH  128
-    #define LCD_HEIGHT 128
-  #elif defined LCD_160X80
-    #define LCD_X_SHIFT 0
-    #define LCD_Y_SHIFT 0
-    #if (LCD_ROTATION == 0) || (LCD_ROTATION == 2)
-      #define LCD_WIDTH  80
-      #define LCD_HEIGHT 160
-    #elif (LCD_ROTATION == 1) || (LCD_ROTATION == 3)
-      #define LCD_WIDTH  160
-      #define LCD_HEIGHT 80
-    #endif
-  #endif
-
-  #if LCD_ROTATION == 0
-    #ifdef LCD_160X80
-      #define LCD_ROTATION_CMD (CMD_MADCTL_MX | CMD_MADCTL_MY | CMD_MADCTL_BGR)
-    #else
-      #define LCD_ROTATION_CMD (CMD_MADCTL_MX | CMD_MADCTL_MY | CMD_MADCTL_RGB)
-    #endif
-  #elif LCD_ROTATION == 1
-    #ifdef LCD_160X80
-      #define LCD_ROTATION_CMD (CMD_MADCTL_MY | CMD_MADCTL_MV | CMD_MADCTL_BGR)
-    #else
-      #define LCD_ROTATION_CMD (CMD_MADCTL_MY | CMD_MADCTL_MV | CMD_MADCTL_RGB)
-    #endif
-  #elif LCD_ROTATION == 2
-    #ifdef LCD_160X80
-      #define LCD_ROTATION_CMD (CMD_MADCTL_BGR)
-    #else
-      #define LCD_ROTATION_CMD (CMD_MADCTL_RGB)
-    #endif
-  #elif LCD_ROTATION == 3
-    #ifdef LCD_160X80
-      #define LCD_ROTATION_CMD (CMD_MADCTL_MX | CMD_MADCTL_MV | CMD_MADCTL_BGR)
-    #else
-      #define LCD_ROTATION_CMD (CMD_MADCTL_MX | CMD_MADCTL_MV | CMD_MADCTL_RGB)
-    #endif
-  #endif
-
-
-#elif defined USE_ST7789
-
-  #ifdef LCD_135X240
-    #if (LCD_ROTATION == 0) || (LCD_ROTATION == 2)
-      #define LCD_WIDTH  135
-      #define LCD_HEIGHT 240
-    #elif (LCD_ROTATION == 1) || (LCD_ROTATION == 3)
-      #define LCD_WIDTH  240
-      #define LCD_HEIGHT 135
-    #endif
-
-  #elif defined LCD_240X240
-    #define LCD_WIDTH  240
-    #define LCD_HEIGHT 240
-    #define LCD_X_SHIFT 0
-    #define LCD_Y_SHIFT 0
-
-  #elif defined LCD_240X280
-    #if (LCD_ROTATION == 0) || (LCD_ROTATION == 2)
-      #define LCD_WIDTH  240
-      #define LCD_HEIGHT 280
-      #define LCD_X_SHIFT 0
-      #define LCD_Y_SHIFT 0
-    #elif (LCD_ROTATION == 1) || (LCD_ROTATION == 3)
-      #define LCD_WIDTH  280
-      #define LCD_HEIGHT 240
-    #endif
-
-  #elif defined LCD_240X320
-    #if (LCD_ROTATION == 0) || (LCD_ROTATION == 2)
-      #define LCD_WIDTH  240
-      #define LCD_HEIGHT 320
-      #define LCD_X_SHIFT 0
-      #define LCD_Y_SHIFT 0
-    #elif (LCD_ROTATION == 1) || (LCD_ROTATION == 3)
-      #define LCD_WIDTH  320
-      #define LCD_HEIGHT 240
-      #define LCD_X_SHIFT 0
-      #define LCD_Y_SHIFT 0
-    #endif
-
-  #endif
-
-
-
-  #if LCD_ROTATION == 0
-    #define LCD_ROTATION_CMD (CMD_MADCTL_MX | CMD_MADCTL_MY | CMD_MADCTL_RGB)
-    #ifdef LCD_135X240
-      #define LCD_X_SHIFT 53
-      #define LCD_Y_SHIFT 40
-
-    #elif defined LCD_240X280
-    #endif
-  #elif LCD_ROTATION == 1
-    #define LCD_ROTATION_CMD (CMD_MADCTL_MY | CMD_MADCTL_MV | CMD_MADCTL_RGB)
-    #ifdef LCD_135X240
-      #define LCD_X_SHIFT 40
-      #define LCD_Y_SHIFT 52
-    #elif defined LCD_240X280
-    #endif
-  #elif LCD_ROTATION == 2
-    #define LCD_ROTATION_CMD (CMD_MADCTL_RGB)
-    #ifdef LCD_135X240
-      #define LCD_X_SHIFT 52
-      #define LCD_Y_SHIFT 40
-    #elif defined LCD_240X280
-      #define LCD_X_SHIFT 20
-      #define LCD_Y_SHIFT 0
-    #elif defined LCD_240X320
-      #define LCD_X_SHIFT 0
-      #define LCD_Y_SHIFT 0
-    #endif
-  #elif LCD_ROTATION == 3
-    #define LCD_ROTATION_CMD (CMD_MADCTL_MX | CMD_MADCTL_MV | CMD_MADCTL_RGB)
-    #ifdef LCD_135X240
-      #define LCD_X_SHIFT 40
-      #define LCD_Y_SHIFT 53
-    #elif defined LCD_240X280
-      #define LCD_X_SHIFT 20
-      #define LCD_Y_SHIFT 0
-    #endif
-  #endif
-#endif
 
 /* LCD Commands */
 typedef enum{
@@ -249,10 +79,34 @@ typedef enum{
 #define color565(r, g, b) (((r & 0xF8) << 8) | ((g & 0xFC) << 3) | ((b & 0xF8) >> 3))
 #define ABS(x) ((x) > 0 ? (x) : -(x))
 
-#define LCD_CON(a,b)  a##b
-//#define LCD_PIN(pin, out) (LCD_CON(pin,_GPIO_Port->BSRR) = (out ? LCD_CON(pin,_Pin) : LCD_CON(pin,_Pin)<<16 ))
+/* ── Hardware ──────────────────────────────────────────── */
+#define LCD_HANDLE            hspi2
+extern SPI_HandleTypeDef      LCD_HANDLE;
 
-extern SPI_HandleTypeDef    LCD_HANDLE;
+#define LCD_DC                SPI2_DC_Pin
+#define LCD_RST               SPI2_RST_Pin
+#define LCD_CS                SPI2_CS_Pin
+
+#define USE_DMA
+/* #define LCD_LOCAL_FB */   /* Uncomment to use local frame buffer (needs ~150 KB RAM) */
+#define DMA_Min_Pixels        32
+
+/* ── Build-time validation ─────────────────────────────── */
+#if !defined(LCD_ROTATION)
+#  define LCD_ROTATION 2   /* default: 180° */
+#endif
+
+#if !defined(USE_ST7789) && !defined(USE_ST7735)
+#  error "No LCD controller selected. Pass -DLCD_CONTROLLER=ST7789 (or ST7735) to CMake."
+#endif
+
+
+/* ── Controller header (geometry + rotation table + init_cmd) ── */
+#if defined USE_ST7789
+#  include "lcd_st7789.h"
+#elif defined USE_ST7735
+#  include "lcd_st7735.h"
+#endif
 
 void LCD_init(void);
 void LCD_SetRotation(uint8_t m);
@@ -260,17 +114,13 @@ void LCD_DrawPixel(int16_t x, int16_t y, uint16_t color);
 void LCD_DrawPixelFB(int16_t x, int16_t y, uint16_t color);
 int8_t LCD_Fill(uint16_t xSta, uint16_t ySta, uint16_t xEnd, uint16_t yEnd, uint16_t color);
 
-/* Graphical functions. */
 int8_t LCD_DrawLine(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
 void LCD_DrawImage(uint16_t x, uint16_t y, UG_BMP* bmp);
 void LCD_InvertColors(uint8_t invert);
 
-/* Text functions. */
 void LCD_PutChar(uint16_t x, uint16_t y, char ch, UG_FONT* font, uint16_t color, uint16_t bgcolor);
-void LCD_PutStr(uint16_t x, uint16_t y,  char *str, UG_FONT* font, uint16_t color, uint16_t bgcolor);
+void LCD_PutStr(uint16_t x, uint16_t y, char *str, UG_FONT* font, uint16_t color, uint16_t bgcolor);
 
-/* Extended Graphical functions. */
-/* Command functions */
 void LCD_TearEffect(uint8_t tear);
 
 /* Simple test function. */
@@ -278,4 +128,4 @@ void LCD_TearEffect(uint8_t tear);
 void LCD_Test(void);
 #endif
 
-#endif // __ST7735_H__
+#endif /* __LCD_H__ */

--- a/AxxSolder_firmware/Drivers/LCD/lcd_st7735.h
+++ b/AxxSolder_firmware/Drivers/LCD/lcd_st7735.h
@@ -1,0 +1,91 @@
+/* lcd_st7735.h
+ * ST7735 controller: display geometry, initialization sequence, rotation table.
+ * Include ONLY from lcd.c after including lcd_config.h.
+ */
+#ifndef LCD_ST7735_H
+#define LCD_ST7735_H
+
+/* ── Display geometry ──────────────────────────────────── */
+#if !defined(LCD_160X128) && !defined(LCD_128X128) && !defined(LCD_160X80)
+#  error "No valid ST7735 size selected. Pass -DLCD_SIZE=160X128|128X128|160X80 to CMake."
+#endif
+
+#ifdef LCD_160X128
+#  define LCD_X_SHIFT 0
+#  define LCD_Y_SHIFT 0
+#  if (LCD_ROTATION == 0) || (LCD_ROTATION == 2)
+#    define LCD_WIDTH  128
+#    define LCD_HEIGHT 160
+#  else
+#    define LCD_WIDTH  160
+#    define LCD_HEIGHT 128
+#  endif
+#elif defined LCD_128X128
+#  define LCD_X_SHIFT 0
+#  define LCD_Y_SHIFT 0
+#  define LCD_WIDTH  128
+#  define LCD_HEIGHT 128
+#elif defined LCD_160X80
+#  define LCD_X_SHIFT 0
+#  define LCD_Y_SHIFT 0
+#  if (LCD_ROTATION == 0) || (LCD_ROTATION == 2)
+#    define LCD_WIDTH  80
+#    define LCD_HEIGHT 160
+#  else
+#    define LCD_WIDTH  160
+#    define LCD_HEIGHT 80
+#  endif
+#endif
+
+/* ST7735 160x80 uses BGR order, other variants use RGB */
+#ifdef LCD_160X80
+#  define ST7735_COLOR_ORDER CMD_MADCTL_BGR
+#else
+#  define ST7735_COLOR_ORDER CMD_MADCTL_RGB
+#endif
+
+/* Initial rotation command — used once in lcd_init_cmd[] */
+#if LCD_ROTATION == 0
+#  define LCD_ROTATION_CMD (CMD_MADCTL_MX | CMD_MADCTL_MY | ST7735_COLOR_ORDER)
+#elif LCD_ROTATION == 1
+#  define LCD_ROTATION_CMD (CMD_MADCTL_MY | CMD_MADCTL_MV | ST7735_COLOR_ORDER)
+#elif LCD_ROTATION == 2
+#  define LCD_ROTATION_CMD (ST7735_COLOR_ORDER)
+#elif LCD_ROTATION == 3
+#  define LCD_ROTATION_CMD (CMD_MADCTL_MX | CMD_MADCTL_MV | ST7735_COLOR_ORDER)
+#endif
+
+/* Runtime rotation: MADCTL byte for each rotation index 0..3 */
+static const uint8_t lcd_rotation_cmds[4] = {
+    CMD_MADCTL_MX | CMD_MADCTL_MY | ST7735_COLOR_ORDER,  /* 0 */
+    CMD_MADCTL_MY | CMD_MADCTL_MV | ST7735_COLOR_ORDER,  /* 1 */
+    ST7735_COLOR_ORDER,                                   /* 2 */
+    CMD_MADCTL_MX | CMD_MADCTL_MV | ST7735_COLOR_ORDER,  /* 3 */
+};
+
+/* Initialization command sequence */
+static const uint8_t lcd_init_cmd[] = {
+    0,  CMD_SLPOUT,
+    3,  CMD_FRMCTR1, 0x01, 0x01, 0x01,
+    3,  CMD_FRMCTR2, 0x01, 0x01, 0x01,
+    6,  CMD_FRMCTR3, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+    1,  CMD_INVCTR,  0x07,
+    3,  CMD_PWCTR1,  0xA2, 0x02, 0x84,
+    1,  CMD_PWCTR2,  0xC5,
+    2,  CMD_PWCTR3,  0x0A, 0x00,
+    2,  CMD_PWCTR4,  0x8A, 0x2A,
+    2,  CMD_PWCTR5,  0x8A, 0xEE,
+    1,  CMD_VMCTR1,  0x0E,
+    1,  CMD_INVOFF,  0x00,
+    1,  CMD_COLMOD,  0x05,
+    2,  CMD_CASET,   0x00, LCD_WIDTH-1,
+    2,  CMD_RASET,   0x00, LCD_HEIGHT-1,
+    1,  CMD_MADCTL,  LCD_ROTATION_CMD,
+    16, CMD_GMCTRP1, 0x02, 0x1c, 0x07, 0x12, 0x37, 0x32, 0x29, 0x2d,
+                     0x29, 0x25, 0x2B, 0x39, 0x00, 0x01, 0x03, 0x10,
+    16, CMD_GMCTRN1, 0x03, 0x1d, 0x07, 0x06, 0x2E, 0x2C, 0x29, 0x2D,
+                     0x2E, 0x2E, 0x37, 0x3F, 0x00, 0x00, 0x02, 0x10,
+    0,  CMD_NORON,
+};
+
+#endif /* LCD_ST7735_H */

--- a/AxxSolder_firmware/Drivers/LCD/lcd_st7789.h
+++ b/AxxSolder_firmware/Drivers/LCD/lcd_st7789.h
@@ -1,0 +1,96 @@
+/* lcd_st7789.h
+ * ST7789 controller: display geometry, initialization sequence, rotation table.
+ * Include ONLY from lcd.c after including lcd_config.h.
+ */
+#ifndef LCD_ST7789_H
+#define LCD_ST7789_H
+
+/* ── Display geometry ──────────────────────────────────── */
+#if !defined(LCD_135X240) && !defined(LCD_240X240) && \
+    !defined(LCD_240X280) && !defined(LCD_240X320)
+#  error "No valid ST7789 size selected. Pass -DLCD_SIZE=135X240|240X240|240X280|240X320 to CMake."
+#endif
+
+#ifdef LCD_135X240
+#  if (LCD_ROTATION == 0) || (LCD_ROTATION == 2)
+#    define LCD_WIDTH   135
+#    define LCD_HEIGHT  240
+#    define LCD_X_SHIFT 53
+#    define LCD_Y_SHIFT 40
+#  else
+#    define LCD_WIDTH   240
+#    define LCD_HEIGHT  135
+#    define LCD_X_SHIFT 40
+#    define LCD_Y_SHIFT 52
+#  endif
+#elif defined LCD_240X240
+#  define LCD_WIDTH   240
+#  define LCD_HEIGHT  240
+#  define LCD_X_SHIFT 0
+#  define LCD_Y_SHIFT 0
+#elif defined LCD_240X280
+#  if (LCD_ROTATION == 0) || (LCD_ROTATION == 2)
+#    define LCD_WIDTH   240
+#    define LCD_HEIGHT  280
+#    define LCD_X_SHIFT 0
+#    define LCD_Y_SHIFT 0
+#  else
+#    define LCD_WIDTH   280
+#    define LCD_HEIGHT  240
+#    define LCD_X_SHIFT 20
+#    define LCD_Y_SHIFT 0
+#  endif
+#elif defined LCD_240X320
+#  if (LCD_ROTATION == 0) || (LCD_ROTATION == 2)
+#    define LCD_WIDTH   240
+#    define LCD_HEIGHT  320
+#    define LCD_X_SHIFT 0
+#    define LCD_Y_SHIFT 0
+#  else
+#    define LCD_WIDTH   320
+#    define LCD_HEIGHT  240
+#    define LCD_X_SHIFT 0
+#    define LCD_Y_SHIFT 0
+#  endif
+#endif
+
+/* Initial rotation command — used once in lcd_init_cmd[] */
+#if LCD_ROTATION == 0
+#  define LCD_ROTATION_CMD (CMD_MADCTL_MX | CMD_MADCTL_MY | CMD_MADCTL_RGB)
+#elif LCD_ROTATION == 1
+#  define LCD_ROTATION_CMD (CMD_MADCTL_MY | CMD_MADCTL_MV | CMD_MADCTL_RGB)
+#elif LCD_ROTATION == 2
+#  define LCD_ROTATION_CMD (CMD_MADCTL_RGB)
+#elif LCD_ROTATION == 3
+#  define LCD_ROTATION_CMD (CMD_MADCTL_MX | CMD_MADCTL_MV | CMD_MADCTL_RGB)
+#endif
+
+/* Runtime rotation: MADCTL byte for each rotation index 0..3 */
+static const uint8_t lcd_rotation_cmds[4] = {
+    CMD_MADCTL_RGB,                                   /* 0 */
+    CMD_MADCTL_MX | CMD_MADCTL_MV | CMD_MADCTL_RGB,  /* 1 */
+    CMD_MADCTL_MX | CMD_MADCTL_MY | CMD_MADCTL_RGB,  /* 2 */
+    CMD_MADCTL_MY | CMD_MADCTL_MV | CMD_MADCTL_RGB,  /* 3 */
+};
+
+/* Initialization command sequence */
+static const uint8_t lcd_init_cmd[] = {
+    0,  CMD_SLPOUT,
+    1,  CMD_COLMOD,  CMD_COLOR_MODE_16bit,
+    5,  CMD_PORCTRL, 0x0C, 0x0C, 0x00, 0x33, 0x33,
+    1,  CMD_GCTRL,   0x35,
+    1,  CMD_VCOMS,   0x19,
+    1,  CMD_LCMCTRL, 0X2C,
+    1,  CMD_VDVVRHEN,0x01,
+    1,  CMD_VRHS,    0x12,
+    1,  CMD_VDVS,    0x20,
+    1,  CMD_FRCTRL2, 0x0F,
+    2,  CMD_PWCTRL1, 0xA4, 0xA1,
+    1,  CMD_MADCTL,  LCD_ROTATION_CMD,
+    14, CMD_GMCTRP1, 0xD0, 0x04, 0x0D, 0x11, 0x13, 0x2B, 0x3F, 0x54, 0x4C, 0x18, 0x0D, 0x0B, 0x1F, 0x23,
+    14, CMD_GMCTRN1, 0xD0, 0x04, 0x0C, 0x11, 0x13, 0x2C, 0x3F, 0x44, 0x51, 0x2F, 0x1F, 0x1F, 0x20, 0x23,
+    0,  CMD_INVON,
+    0,  CMD_NORON,
+};
+
+#endif /* LCD_ST7789_H */


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                  
                                                                                                                                                                                              
  - Extracted controller-specific logic (init sequence, MADCTL rotation                                                                                                                       
    table, display geometry) from the monolithic `lcd.c/h` into dedicated                                                                                                                     
    headers: `lcd_st7789.h` and `lcd_st7735.h`                                                                                                                                                
  - `lcd.h` retains the public API, command enum, hardware config, and                                                                                                                        
    build-time validation; it selects and includes the correct controller                                                                                                                     
    header automatically                                                                                                                                                                      
  - `lcd.c` now has a single `#include "lcd.h"` — no controller ifdefs                                                                                                                        
  - `LCD_SetRotation()` simplified from a switch/case with preprocessor                                                                                                                       
    guards to a one-line table lookup via `lcd_rotation_cmds[]`                                                                                                                               
                                                                                                                                                                                              
  ## Build configuration                                                                                                                                                                      
                                                                                                                                                                                              
  Controller, panel size and default rotation are now CMake options with                                                                                                                      
  sensible defaults (unchanged from before):
                                                                                                                                                                                              
  | Option | Default | Values |                             
  |---|---|---|                                                                                                                                                                               
  | `LCD_CONTROLLER` | `ST7789` | `ST7789`, `ST7735` |      
  | `LCD_SIZE` | `240X320` | `240X320`, `240X280`, `240X240`, `135X240`, `160X128`, `128X128`, `160X80` |                                                                                     
  | `LCD_ROTATION` | `2` | `0`–`3` |                                                                                                                                                          
                                                                                                                                                                                              
  Example:                                                                                                                                                                                    
  ```cmake                                                                                                                                                                                    
  cmake -DLCD_CONTROLLER=ST7735 -DLCD_SIZE=160X128 -DLCD_ROTATION=0 ..
                                                                                                                                                                                              
  Passing an unsupported size for the selected controller now produces a                                                                                                                      
  descriptive compile-time error pointing to the valid options for that                                                                                                                       
  controller.  