### PR TITLE
perf: reduce Flash usage from ~96% to 53% through linker and compiler optimizations

### DIFF
--- a/AxxSolder_firmware/CMakeLists.txt
+++ b/AxxSolder_firmware/CMakeLists.txt
@@ -50,6 +50,7 @@ target_compile_options(${EXECUTABLE} PRIVATE
 	-Wall
 	-Wpedantic
 	-Wno-unused-parameter
+	-Wdouble-promotion
 )
 
 target_link_options(${EXECUTABLE} PRIVATE

--- a/AxxSolder_firmware/CMakeLists.txt
+++ b/AxxSolder_firmware/CMakeLists.txt
@@ -47,6 +47,7 @@ set(CPU_PARAMETERS ${CPU_PARAMETERS}
 
 target_compile_options(${EXECUTABLE} PRIVATE
     ${CPU_PARAMETERS}
+	-Os
 	-Wall
 	-Wpedantic
 	-Wno-unused-parameter

--- a/AxxSolder_firmware/CMakeLists.txt
+++ b/AxxSolder_firmware/CMakeLists.txt
@@ -57,7 +57,6 @@ target_link_options(${EXECUTABLE} PRIVATE
 	${CPU_PARAMETERS}
 	-Wl,-Map=${CMAKE_PROJECT_NAME}.map
 	--specs=nosys.specs
-	-u _printf_float                # STDIO float formatting support
 	-Wl,--start-group
 	-lc
 	-lm

--- a/AxxSolder_firmware/Core/Src/main.c
+++ b/AxxSolder_firmware/Core/Src/main.c
@@ -62,12 +62,12 @@ DEBUG_VERBOSITY_t debugLevel = DEBUG_INFO;
 
 #define KP_T245 					8
 #define KI_T245 					2
-#define KD_T245 					0.5
+#define KD_T245 					0.5f
 #define MAX_I_T245 					300
 
 #define KP_No_name 					8
 #define KI_No_name 					2
-#define KD_No_name 					0.5
+#define KD_No_name 					0.5f
 #define MAX_I_No_name 				300
 
 /* General PID parameters */
@@ -176,16 +176,16 @@ uint16_t TC_outliers_detected = 0;
 #define EMERGENCY_SHUTDOWN_TEMPERATURE 490
 
 /* Constants for scaling input voltage ADC value*/
-#define VOLTAGE_COMPENSATION 0.00840442388
-#define CURRENT_COMPENSATION 0.002864
+#define VOLTAGE_COMPENSATION 0.00840442388f
+#define CURRENT_COMPENSATION 0.002864f
 
 /* Constants for scaling power in W to correct duty cycle */
-#define POWER_CONVERSION_FACTOR 0.123
+#define POWER_CONVERSION_FACTOR 0.123f
 
 /* Min allowed bus voltage and power */
-#define MIN_BUSVOLTAGE 8.0
-#define MIN_BUSPOWER 8.0
-#define USB_PD_POWER_REDUCTION_FACTOR 1.0
+#define MIN_BUSVOLTAGE 8.0f
+#define MIN_BUSPOWER 8.0f
+#define USB_PD_POWER_REDUCTION_FACTOR 1.0f
 
 /* Max allowed power per handle type */
 #define NT115_MAX_POWER 	22
@@ -194,22 +194,22 @@ uint16_t TC_outliers_detected = 0;
 #define No_name_MAX_POWER 	150
 
 /* TC Compensation constants */
-#define TC_COMPENSATION_X2_NT115 (5.1026665462522864e-05)
-#define TC_COMPENSATION_X1_NT115 0.42050803230712813
-#define TC_COMPENSATION_X0_NT115 20.14538589052425
+#define TC_COMPENSATION_X2_NT115 (5.1026665462522864e-05f)
+#define TC_COMPENSATION_X1_NT115 0.42050803230712813f
+#define TC_COMPENSATION_X0_NT115 20.14538589052425f
 
-#define TC_COMPENSATION_X2_T210 (4.223931712905644e-06)
-#define TC_COMPENSATION_X1_T210 0.31863796444354214
-#define TC_COMPENSATION_X0_T210 20.968033870812942
+#define TC_COMPENSATION_X2_T210 (4.223931712905644e-06f)
+#define TC_COMPENSATION_X1_T210 0.31863796444354214f
+#define TC_COMPENSATION_X0_T210 20.968033870812942f
 
-#define TC_COMPENSATION_X2_T245 (-4.735112838956741e-07)
-#define TC_COMPENSATION_X1_T245 0.11936452029674384
-#define TC_COMPENSATION_X0_T245 23.777399955382318
+#define TC_COMPENSATION_X2_T245 (-4.735112838956741e-07f)
+#define TC_COMPENSATION_X1_T245 0.11936452029674384f
+#define TC_COMPENSATION_X0_T245 23.777399955382318f
 
 /* Constants for internal MCU temperture */
-#define V30 		0.76 			// from datasheet
-#define VSENSE 		(3.3/4096.0) 	// VSENSE value
-#define Avg_Slope 	0.0025 			// 2.5mV from datasheet
+#define V30 		0.76f 			// from datasheet
+#define VSENSE 		(3.3f/4096.0f) 	// VSENSE value
+#define Avg_Slope 	0.0025f 		// 2.5mV from datasheet
 
 /* Largest delta temperature before detecting a faulty or missing cartridge */
 #define MAX_TC_DELTA_FAULTDETECTION 50
@@ -510,7 +510,7 @@ void get_thermocouple_temperature(){
 	/* --- Step 1: Outlier filter on raw ADC data --- */
 	TC_temp_from_ADC_previous = TC_temp_from_ADC;
 	TC_temp_from_ADC = get_mean_ADC_reading_indexed(1);
-	TC_temp_from_ADC_diff = fabs(TC_temp_from_ADC_previous - TC_temp_from_ADC);
+	TC_temp_from_ADC_diff = fabsf(TC_temp_from_ADC_previous - TC_temp_from_ADC);
 
 	if((TC_temp_from_ADC_diff > TC_OUTLIERS_THRESHOLD) && (TC_outliers_detected < 2)){
 		TC_outliers_detected++;
@@ -813,7 +813,7 @@ void update_display(){
 		LCD_PutStr(125, 255, DISPLAY_buffer, FONT_arial_17X18, RGB_to_BRG(C_WHITE), RGB_to_BRG(C_BLACK));
 
 		memset(&DISPLAY_buffer, '\0', sizeof(DISPLAY_buffer));
-		if(convert_temperature(sensor_values.mcu_temperature) < 99.5){
+		if(convert_temperature(sensor_values.mcu_temperature) < 99.5f){
 			sprintf(DISPLAY_buffer, "%d", (int)convert_temperature(sensor_values.mcu_temperature));
 		}
 		else{
@@ -899,7 +899,7 @@ void update_display(){
 		LCD_PutStr(170, 195, DISPLAY_buffer, FONT_arial_17X18, RGB_to_BRG(C_WHITE), RGB_to_BRG(C_BLACK));
 
 		memset(&DISPLAY_buffer, '\0', sizeof(DISPLAY_buffer));
-		if(convert_temperature(sensor_values.mcu_temperature) < 99.5){
+		if(convert_temperature(sensor_values.mcu_temperature) < 99.5f){
 			sprintf(DISPLAY_buffer, "  %d", (int)convert_temperature(sensor_values.mcu_temperature));
 		}
 		else{
@@ -1385,14 +1385,14 @@ void get_stand_status(){
 
 		/* PRESTANDBY -> STANDBY after delay */
 		if((sensor_values.current_state == PRESTANDBY) &&
-		   (HAL_GetTick() - previous_millis_prestandby >= flash_values.standby_delay * 1000.0)){
+		   (HAL_GetTick() - previous_millis_prestandby >= flash_values.standby_delay * 1000.0f)){
 			change_state(STANDBY);
 			previous_millis_standby = HAL_GetTick();
 		}
 
 		/* STANDBY -> SLEEP */
 		if((sensor_values.current_state == STANDBY) &&
-		   (HAL_GetTick() - previous_millis_standby >= flash_values.standby_time * 60000.0)){
+		   (HAL_GetTick() - previous_millis_standby >= flash_values.standby_time * 60000.0f)){
 			change_state(SLEEP);
 		}
 
@@ -1404,7 +1404,7 @@ void get_stand_status(){
 	}
 
 	/* Handle removed from stand → always go to RUN */
-	if(sensor_values.in_stand < 0.2){
+	if(sensor_values.in_stand < 0.2f){
 		if ((sensor_values.current_state == SLEEP) ||
 		    (sensor_values.current_state == STANDBY) ||
 		    (sensor_values.current_state == PRESTANDBY) ||
@@ -1756,7 +1756,7 @@ int main(void)
 	Moving_Average_Init(&handle2_sense_filterStruct,(uint32_t)20);
 
 	/* initialize hysteresis functions */
-	Hysteresis_Init(&thermocouple_temperature_filtered_hysteresis, 0.5);
+	Hysteresis_Init(&thermocouple_temperature_filtered_hysteresis, 0.5f);
 
 	/* Init and fill filter structures with initial values */
 	for (int i = 0; i<200;i++){
@@ -1931,7 +1931,7 @@ int main(void)
 		/* PID Tuning manual control */
 		#ifdef PID_TUNING
 		custom_temperature_on = 1;
-		PID_SetTunings(&TPID, Kp_tuning, Ki_tuning, Kd_tuning/100.0);
+		PID_SetTunings(&TPID, Kp_tuning, Ki_tuning, Kd_tuning/100.0f);
 		PID_SetILimits(&TPID, -PID_MAX_I_LIMIT_tuning, PID_MAX_I_LIMIT_tuning); 	// Set max and min I limit
 		sensor_values.set_temperature = temperature_tuning;
 		#endif

--- a/AxxSolder_firmware/Core/Src/menu_settings.c
+++ b/AxxSolder_firmware/Core/Src/menu_settings.c
@@ -307,27 +307,27 @@ void normalize_param(uint16_t index) {
 
         // --- Parameter with range 1 to 10 (10 values)
         case 21:
-            *p = 1 + fmod(round(fmod(fabs(*p), 10)), 10);  // 1..10
+            *p = 1.0f + fmodf(roundf(fmodf(fabsf(*p), 10.0f)), 10.0f);  // 1..10
             break;
 
         // --- Integer parameter (e.g. sensor type, flag)
         case 1:
-            *p = round(*p);  // Round to nearest integer
+            *p = roundf(*p);  // Round to nearest integer
             break;
 
         // --- Temperature parameters: clamped to the allowed range
         case 0: case 2: case 6: case 7:
-            *p = fmod(round(fmod(fabs(*p), MAX_SELECTABLE_TEMPERATURE + 1)), MAX_SELECTABLE_TEMPERATURE + 1);
+            *p = fmodf(roundf(fmodf(fabsf(*p), MAX_SELECTABLE_TEMPERATURE + 1)), MAX_SELECTABLE_TEMPERATURE + 1);
             break;
 
         // --- Power parameter: 0..(MAX_POWER + 4)
        case 28: case 29: case 30: case 31:
-            *p = fmod(round(fmod(fabs(*p), MAX_POWER + 5)), MAX_POWER + 5);
+            *p = fmodf(roundf(fmodf(fabsf(*p), MAX_POWER + 5)), MAX_POWER + 5);
             break;
 
         // --- Default: take absolute value (positive only)
         default:
-            *p = fabs(*p);
+            *p = fabsf(*p);
             break;
     }
 }

--- a/AxxSolder_firmware/Core/Src/pid.c
+++ b/AxxSolder_firmware/Core/Src/pid.c
@@ -69,7 +69,7 @@ uint8_t PID_Compute(PID_TypeDef *uPID){
 		if (timeChange == 0){
 			return 0;
 		}
-		timeChange_in_seconds = timeChange/1000.0;
+		timeChange_in_seconds = timeChange/1000.0f;
 		/* Compute all the working error variables */
 		input   = *uPID->MyInput;
 		error   = *uPID->MySetpoint - input;
@@ -103,7 +103,7 @@ uint8_t PID_Compute(PID_TypeDef *uPID){
 		}
 
 		/* only add I part if error is smaller than IminError and scale it from IminError to 0 */
-		if(error > fabs(uPID->IminError)){
+		if(error > fabsf(uPID->IminError)){
 			uPID->OutputSum = 0;
 		}
 

--- a/AxxSolder_firmware/Core/Src/stusb4500.c
+++ b/AxxSolder_firmware/Core/Src/stusb4500.c
@@ -83,7 +83,7 @@ bool stusb_set_highest_pdo(uint8_t *maxPower, uint8_t currentPdoIndex){
 	uint8_t highPowerPdoIdx = 0;
 	uint8_t maxWattage = 0;
 	for(uint8_t i = 0; i < pdos.numPDOs; i++){
-		uint8_t w = pdos.pdos[i].current*0.05 * pdos.pdos[i].voltage*0.01;
+		uint8_t w = pdos.pdos[i].current*0.05f * pdos.pdos[i].voltage*0.01f;
 		if(w>maxWattage){
 			highPowerPdoIdx = (w>maxWattage) ? i : highPowerPdoIdx;
 			maxWattage = w;

--- a/AxxSolder_firmware/Drivers/LCD/lcd.c
+++ b/AxxSolder_firmware/Drivers/LCD/lcd.c
@@ -614,6 +614,8 @@ void LCD_init(void)
 }
 
 
+#ifdef LCD_ENABLE_TEST
+
 #define DEFAULT_FONT FONT_6X8
 
 static uint32_t draw_time=0;
@@ -980,3 +982,5 @@ static void window_1_callback(UG_MESSAGE *msg __unused)
     }
 */
 }
+
+#endif /* LCD_ENABLE_TEST */

--- a/AxxSolder_firmware/Drivers/LCD/lcd.h
+++ b/AxxSolder_firmware/Drivers/LCD/lcd.h
@@ -274,6 +274,8 @@ void LCD_PutStr(uint16_t x, uint16_t y,  char *str, UG_FONT* font, uint16_t colo
 void LCD_TearEffect(uint8_t tear);
 
 /* Simple test function. */
+#ifdef LCD_ENABLE_TEST
 void LCD_Test(void);
+#endif
 
 #endif // __ST7735_H__


### PR DESCRIPTION
  ## Summary
                                                                                                                                                                                              
  This branch eliminates ~53 KB of unnecessary Flash usage through a series                                                                                                                   
  of targeted build and source changes. No functional behavior is changed.                                                                                                                    
                                                                                                                                                                                              
  ### Changes                                               
                                                                                                                                                                                              
  - **Guard `LCD_Test` behind `LCD_ENABLE_TEST`** — test-only code and all                                                                                                                    
    its helpers are excluded from compilation unless `-DLCD_ENABLE_TEST` is
    passed. Makes test-only intent explicit.                                                                                                                                                  
                                                                                                                                                                                              
  - **Remove `-u _printf_float` linker flag** — this flag force-linked the                                                                                                                    
    float-capable printf even though no production format string uses `%f`,                                                                                                                   
    `%g`, or `%e`. Removing it saves ~10 KB.                                                                                                                                                  
                                                            
  - **Replace `double` literals and functions with `float` equivalents** —                                                                                                                    
    all floating-point constants now carry the `f` suffix (`0.5` → `0.5f`),
    and `fabs`/`fmod`/`round` are replaced with `fabsf`/`fmodf`/`roundf`                                                                                                                      
    throughout `main.c`, `pid.c`, `menu_settings.c`, `stusb4500.c`.                                                                                                                           
    Eliminates the ~3.6 KB soft-double arithmetic library.                                                                                                                                    
                                                                                                                                                                                              
  - **Add `-Wdouble-promotion` compiler warning** — any future implicit                                                                                                                       
    `float` → `double` promotion will produce a compiler warning, preventing                                                                                                                  
    regression of the above.                                                                                                                                                                  
                                                                                                                                                                                              
  - **Switch to `-Os` (size optimization)** — replaces the default                                                                                                                            
    unspecified optimization level with `-Os`, which disables loop unrolling                                                                                                                  
    and aggressive inlining while keeping all other optimizations. Saves                                                                                                                      
    another ~16 KB.                                                                                                                                                                           
   
  ## Flash usage                                                                                                                                                                              

  | | Flash used | % of 128 KB |                                                                                                                                                              
  |---|---|---|
  | Before (debug build, no optimizations) | ~123 KB | ~96% |                                                                                                                                 
  | After removing `-u _printf_float` | 90,064 B | 68.7% |                                                                                                                                    
  | After `double` → `float` | 86,316 B | 65.9% |
  | After `-Os` | **69,956 B** | **53.4%** |                                                                                                                                                  

  **Net savings: ~53 KB. Free Flash: ~58 KB.**                                                                                                                                                    