### PR TITLE
fix: add missing stdio.h include in debug.c

### DIFF
--- a/AxxSolder_firmware/Core/Src/debug.c
+++ b/AxxSolder_firmware/Core/Src/debug.c
@@ -1,4 +1,5 @@
 #include "debug.h"
+#include <stdio.h>
 #include "string.h"
 
 extern UART_HandleTypeDef huart1;


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                  
                                                                                                                                                                                              
  - Adds `#include <stdio.h>` to `debug.c` to fix implicit declaration                                                                                                                        
    of `sprintf`                                                                                                                                                                              
                                                            
  ## Problem                                                                                                                                                                                  
   
  The Debug build defines the `DEBUG` macro, which activates the                                                                                                                              
  `#ifdef DEBUG` blocks in `debug.c`. These blocks use `sprintf`, but
  `<stdio.h>` was never explicitly included.
                                                                                                                                                                                              
  In the Release build this went unnoticed — `sprintf` was pulled in
  transitively through other headers. In the Debug build the include                                                                                                                          
  chain is different, so `sprintf` appeared undeclared and the build                                                                                                                          
  failed with:                                                                                                                                                                                
                                                                                                                                                                                              
      error: implicit declaration of function 'sprintf'                                                                                                                                       
             [-Wimplicit-function-declaration]                                                                                                                                                
                                                                                                                                                                                              
  ## Changes                                                                                                                                                                                  
                                                            
  - `AxxSolder_firmware/Core/Src/debug.c` — add `#include <stdio.h>` 